### PR TITLE
增加tornado支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 MANIFEST
 dist
+.idea
+.vscode
+.project
+testcode

--- a/python3/hprose/__init__.py
+++ b/python3/hprose/__init__.py
@@ -18,12 +18,12 @@
 #                                                          #
 ############################################################
 
-from hprose.common import HproseResultMode, HproseException
-from hprose.io import HproseTags, HproseClassManager, HproseRawReader, HproseReader, HproseWriter, HproseFormatter
-from hprose.client import HproseClient
-from hprose.server import HproseService
-from hprose.httpclient import HproseHttpClient
-from hprose.httpserver import HproseHttpService, HproseHttpServer, UrlMapMiddleware
+from .common import HproseResultMode, HproseException
+from .io import HproseTags, HproseClassManager, HproseRawReader, HproseReader, HproseWriter, HproseFormatter
+from .client import HproseClient
+from .server import HproseService
+from .httpclient import HproseHttpClient
+from .httpserver import HproseHttpService, HproseHttpServer, UrlMapMiddleware
 
 ResultMode = HproseResultMode
 Tags = HproseTags

--- a/python3/hprose/client.py
+++ b/python3/hprose/client.py
@@ -20,15 +20,18 @@
 
 import threading
 from sys import modules
-from hprose.io import BytesIO, HproseTags, HproseWriter, HproseReader
-from hprose.common import HproseResultMode, HproseException
+from .io import BytesIO, HproseTags, HproseWriter, HproseReader
+from .common import HproseResultMode, NetErrorException, ServiceException
+
 
 class _Method(object):
     def __init__(self, invoke, name):
         self.__invoke = invoke
         self.__name = name
+
     def __getattr__(self, name):
         return _Method(self.__invoke, self.__name + '_' + name)
+
     def __call__(self, *args, **kargs):
         callback = kargs.get('callback', None)
         onerror = kargs.get('onerror', None)
@@ -37,11 +40,14 @@ class _Method(object):
         simple = kargs.get('simple', None)
         return self.__invoke(self.__name, list(args), callback, onerror, byref, resultMode, simple)
 
+
 class _Proxy(object):
     def __init__(self, invoke):
         self.__invoke = invoke
+
     def __getattr__(self, name):
         return _Method(self.__invoke, name)
+
 
 class _AsyncInvoke(object):
     def __init__(self, invoke, name, args, callback, onerror, byref, resultMode, simple):
@@ -53,6 +59,7 @@ class _AsyncInvoke(object):
         self.__byref = byref
         self.__resultMode = resultMode
         self.__simple = simple
+
     def __call__(self):
         try:
             result = self.__invoke(self.__name, self.__args, self.__byref, self.__resultMode, self.__simple)
@@ -69,12 +76,13 @@ class _AsyncInvoke(object):
         except (KeyboardInterrupt, SystemExit):
             raise
         except Exception as e:
-            if self.__onerror != None:
+            if self.__onerror is not None:
                 self.__onerror(self.__name, e)
 
+
 class HproseClient(object):
-    def __init__(self, uri = None):
-        self.__filters = []
+    def __init__(self, uri=None):
+        self.__filters = []  # type: list[.common.HproseFilter]
         self.onError = None
         self.simple = False
         self._uri = uri
@@ -83,46 +91,49 @@ class HproseClient(object):
     def __getattr__(self, name):
         return _Method(self.invoke, name)
 
-    def invoke(self, name, args = (), callback = None, onerror = None, byref = False, resultMode = HproseResultMode.Normal, simple = None):
-        if simple == None: simple = self.simple
-        if callback == None:
+    def invoke(self, name, args=(), callback=None, onerror=None, byref=False, resultMode=HproseResultMode.Normal,
+               simple=None):
+        if simple is None:
+            simple = self.simple
+        if callback is None:
             return self.__invoke(name, args, byref, resultMode, simple)
         else:
             if isinstance(callback, str):
                 callback = getattr(modules['__main__'], callback, None)
             if not hasattr(callback, '__call__'):
-                raise HproseException("callback must be callable")
-            if onerror == None:
+                raise RuntimeError("callback must be callable")
+            if onerror is None:
                 onerror = self.onError
-            if onerror != None:
+            if onerror is not None:
                 if isinstance(onerror, str):
                     onerror = getattr(modules['__main__'], onerror, None)
                 if not hasattr(onerror, '__call__'):
-                    raise HproseException("onerror must be callable")
-            threading.Thread(target = _AsyncInvoke(self.__invoke, name, args,
-                                                   callback, onerror,
-                                                   byref, resultMode, simple)).start()
+                    raise RuntimeError("onerror must be callable")
+            threading.Thread(target=_AsyncInvoke(self.__invoke, name, args,
+                                                 callback, onerror,
+                                                 byref, resultMode, simple)).start()
 
-    def useService(self, uri = None):
-        if uri != None: self.setUri(uri)
+    def useService(self, uri=None):
+        if uri is not None:
+            self.setUri(uri)
         return _Proxy(self.invoke)
 
     def setUri(self, uri):
         self._uri = uri
 
-    uri = property(fset = setUri)
+    uri = property(fset=setUri)
 
     def getFilter(self):
-        if (len(self.__filters) == 0):
+        if len(self.__filters) == 0:
             return None
         return self.__filters[0]
 
     def setFilter(self, _filter):
         self.__filters = []
-        if _filter != None:
+        if _filter is not None:
             self.__filters.append(_filter)
 
-    filter = property(fget = getFilter, fset = setFilter)
+    filter = property(fget=getFilter, fset=setFilter)
 
     def addFilter(self, _filter):
         self.__filters.append(_filter)
@@ -133,7 +144,7 @@ class HproseClient(object):
     def _sendAndReceive(self, data):
         raise NotImplementedError
 
-    def __doOutput(self, name, args, byref, simple):
+    def _doOutput(self, name, args, byref, simple):
         stream = BytesIO()
         writer = HproseWriter(stream, simple)
         stream.write(HproseTags.TagCall)
@@ -149,11 +160,11 @@ class HproseClient(object):
             data = _filter.outputFilter(data, self)
         return data
 
-    def __doInput(self, data, args, resultMode):
+    def _doInput(self, data, args, resultMode):
         for _filter in reversed(self.__filters):
             data = _filter.inputFilter(data, self)
-        if data == None or len(data) == 0 or data[len(data) - 1:] != HproseTags.TagEnd:
-            raise HproseException("Wrong Response: \r\n%s" % str(data, 'utf-8'))
+        if data is None or len(data) == 0 or data[len(data) - 1:] != HproseTags.TagEnd:
+            raise ServiceException("Wrong Response: \r\n%s" % str(data))
         if resultMode == HproseResultMode.RawWithEndTag:
             return data
         if resultMode == HproseResultMode.Raw:
@@ -185,14 +196,14 @@ class HproseClient(object):
                     reader.reset()
                     error = reader.readString()
                 else:
-                    raise HproseException("Wrong Response: \r\n%s" % str(data, 'utf-8'))
-            if error != None:
-                raise HproseException(error)
+                    raise ServiceException("Wrong Response: \r\n%s" % str(data))
+            if error is not None:
+                raise ServiceException(error)
         finally:
             stream.close()
         return result
 
-    def __invoke(self, name, args, byref, resultMode, simple):
+    def _invoke(self, name, args, byref, resultMode, simple):
         data = self.__doOutput(name, args, byref, simple)
         data = self._sendAndReceive(data)
         return self.__doInput(data, args, resultMode)

--- a/python3/hprose/common.py
+++ b/python3/hprose/common.py
@@ -24,11 +24,24 @@ class HproseResultMode:
     Raw = 2
     RawWithEndTag = 3
 
+
 class HproseException(Exception):
     pass
 
+
+class NetErrorException(HproseException):
+    """网络异常，数据没有发送到服务方"""
+    pass
+
+
+class ServiceException(HproseException):
+    """通讯成功，服务方主动抛出的异常"""
+    pass
+
+
 class HproseFilter(object):
     def inputFilter(self, data, context):
-        return data;
+        return data
+
     def outputFilter(self, data, context):
-        return data;
+        return data

--- a/python3/hprose/httpserver.py
+++ b/python3/hprose/httpserver.py
@@ -22,10 +22,11 @@ import re, datetime
 import urllib.parse
 from math import trunc
 from random import random
-from hprose.server import HproseService
+from .server import HproseService
+
 
 class HproseHttpService(HproseService):
-    def __init__(self, sessionName = None):
+    def __init__(self, sessionName=None):
         super(HproseHttpService, self).__init__()
         self.crossDomain = False
         self.p3p = False
@@ -39,7 +40,7 @@ class HproseHttpService(HproseService):
         self._lastModified = datetime.datetime.utcnow().strftime("%a, %d %b %Y %H:%M:%S GMT")
         self._etag = '"%x:%x"' % (trunc(random() * 2147483647), trunc(random() * 2147483647))
 
-    def __call__(self, environ, start_response = None):
+    def __call__(self, environ, start_response=None):
         result = self.handle(environ)
         # WSGI 2
         if start_response == None:
@@ -58,7 +59,7 @@ class HproseHttpService(HproseService):
         path = (environ['SCRIPT_NAME'] + environ['PATH_INFO']).lower()
         if (path == '/crossdomain.xml'):
             if ((environ.get('HTTP_IF_MODIFIED_SINCE', '') == self._lastModified) and
-                (environ.get('HTTP_IF_NONE_MATCH', '') == self._etag)):
+                    (environ.get('HTTP_IF_NONE_MATCH', '') == self._etag)):
                 return ['304 Not Modified', [], [b'']]
             else:
                 header = [('Content-Type', 'text/xml'),
@@ -71,7 +72,7 @@ class HproseHttpService(HproseService):
         path = (environ['SCRIPT_NAME'] + environ['PATH_INFO']).lower()
         if (path == '/clientaccesspolicy.xml'):
             if ((environ.get('HTTP_IF_MODIFIED_SINCE', '') == self._lastModified) and
-                (environ.get('HTTP_IF_NONE_MATCH', '') == self._etag)):
+                    (environ.get('HTTP_IF_NONE_MATCH', '') == self._etag)):
                 return ['304 Not Modified', [], [b'']]
             else:
                 header = [('Content-Type', 'text/xml'),
@@ -84,9 +85,9 @@ class HproseHttpService(HproseService):
         header = [('Content-Type', 'text/plain')]
         if self.p3p:
             header.append(('P3P', 'CP="CAO DSP COR CUR ADM DEV TAI PSA PSD ' +
-                         'IVAi IVDi CONi TELo OTPi OUR DELi SAMi OTRi UNRi ' +
-                         'PUBi IND PHY ONL UNI PUR FIN COM NAV INT DEM CNT ' +
-                         'STA POL HEA PRE GOV"'))
+                           'IVAi IVDi CONi TELo OTPi OUR DELi SAMi OTRi UNRi ' +
+                           'PUBi IND PHY ONL UNI PUR FIN COM NAV INT DEM CNT ' +
+                           'STA POL HEA PRE GOV"'))
         if self.crossDomain:
             origin = environ.get("HTTP_ORIGIN", "null")
             if origin != "null":
@@ -129,7 +130,7 @@ class HproseHttpService(HproseService):
         finally:
             f.close()
 
-    crossDomainXmlFile = property(fget = _getCrossDomainXmlFile, fset = _setCrossDomainXmlFile)
+    crossDomainXmlFile = property(fget=_getCrossDomainXmlFile, fset=_setCrossDomainXmlFile)
 
     def _getCrossDomainXmlContent(self):
         return self._crossDomainXmlContent
@@ -138,7 +139,7 @@ class HproseHttpService(HproseService):
         self._crossDomainXmlFile = None
         self._crossDomainXmlContent = value
 
-    crossDomainXmlContent = property(fget = _getCrossDomainXmlContent, fset = _setCrossDomainXmlContent)
+    crossDomainXmlContent = property(fget=_getCrossDomainXmlContent, fset=_setCrossDomainXmlContent)
 
     def _getClientAccessPolicyXmlFile(self):
         return self._clientAccessPolicyXmlFile
@@ -151,7 +152,7 @@ class HproseHttpService(HproseService):
         finally:
             f.close()
 
-    clientAccessPolicyXmlFile = property(fget = _getClientAccessPolicyXmlFile, fset = _setClientAccessPolicyXmlFile)
+    clientAccessPolicyXmlFile = property(fget=_getClientAccessPolicyXmlFile, fset=_setClientAccessPolicyXmlFile)
 
     def _getClientAccessPolicyXmlContent(self):
         return self._clientAccessPolicyXmlContent
@@ -160,7 +161,9 @@ class HproseHttpService(HproseService):
         self._clientAccessPolicyXmlFile = None
         self._clientAccessPolicyXmlContent = value
 
-    clientAccessPolicyXmlContent = property(fget = _getClientAccessPolicyXmlContent, fset = _setClientAccessPolicyXmlContent)
+    clientAccessPolicyXmlContent = property(fget=_getClientAccessPolicyXmlContent,
+                                            fset=_setClientAccessPolicyXmlContent)
+
 
 ################################################################################
 # UrlMapMiddleware                                                             #
@@ -180,7 +183,7 @@ class UrlMapMiddleware:
             compiled = re.compile(regexp)
             self.__url_mapping.append((compiled, app))
 
-    def __call__(self, environ, start_response = None):
+    def __call__(self, environ, start_response=None):
         script_name = environ['SCRIPT_NAME']
         path_info = environ['PATH_INFO']
         path = urllib.parse.quote(script_name) + urllib.parse.quote(path_info)
@@ -191,12 +194,13 @@ class UrlMapMiddleware:
             return [b'404 Not Found']
         return ('404 Not Found', [('Content-Type', 'text/plain')], [b'404 Not Found'])
 
+
 ################################################################################
 # HproseHttpServer                                                             #
 ################################################################################
 
 class HproseHttpServer(HproseHttpService):
-    def __init__(self, host = '', port = 80, app = None):
+    def __init__(self, host='', port=80, app=None):
         super(HproseHttpServer, self).__init__()
         self.host = host
         self.port = port

--- a/python3/hprose/io.py
+++ b/python3/hprose/io.py
@@ -25,7 +25,7 @@ from inspect import isclass
 from sys import modules
 from threading import RLock
 from uuid import UUID
-from hprose.common import HproseException
+from .common import HproseException
 
 ZERO = datetime.timedelta(0)
 

--- a/python3/hprose/server.py
+++ b/python3/hprose/server.py
@@ -21,8 +21,8 @@
 import types, traceback
 from io import BytesIO
 from sys import modules, exc_info
-from hprose.io import HproseTags, HproseWriter, HproseReader
-from hprose.common import HproseResultMode, HproseException
+from .io import HproseTags, HproseWriter, HproseReader
+from .common import HproseResultMode, HproseException
 
 def _getInstanceMethods(cls):
     v = vars(cls)

--- a/python3/hprose/tornado/client.py
+++ b/python3/hprose/tornado/client.py
@@ -1,0 +1,114 @@
+import sys
+
+from ..client import (
+    HproseClient as OldClient,
+)
+from ..common import HproseResultMode
+
+# 仅仅是为了type hint而引入
+from tornado.gen import Future
+
+
+class _AsyncInvoke(object):
+    def __init__(self, invoke, name, args, callback, onerror, byref, resultMode, simple):
+        self.__invoke = invoke
+        self.__name = name
+        self.__args = args
+        self.__callback = callback
+        self.__onerror = onerror
+        self.__byref = byref
+        self.__resultMode = resultMode
+        self.__simple = simple
+
+    async def __call__(self):
+        future = self.__invoke(
+            self.__name, self.__args, self.__byref,
+            self.__resultMode, self.__simple)  # type: Future
+
+        if hasattr(self.__callback, '__code__'):
+            argcount = self.__callback.__code__.co_argcount
+            if argcount == 0:
+                future.add_done_callback(lambda f: self.__callback())
+            elif argcount == 1:
+                future.add_done_callback(lambda f: self.__callback(f.result()))
+            else:
+                future.add_done_callback(lambda f: self.__callback(f.result(), self.__args))
+        else:
+            future.add_done_callback(lambda f: self.__callback(f.result(), self.__args))
+
+        def on_error(f):
+            # type: (Future)->None
+            if f.exception():
+                self.__onerror(self.__name, f.exception())
+
+        if self.__onerror is not None:
+            future.add_done_callback(on_error)
+        return await future
+
+
+class _Method(object):
+    def __init__(self, invoke, name):
+        self.__invoke = invoke
+        self.__name = name
+
+    def __getattr__(self, name):
+        return _Method(self.__invoke, self.__name + '_' + name)
+
+    async def __call__(self, *args, **kargs):
+        callback = kargs.get('callback', None)
+        onerror = kargs.get('onerror', None)
+        byref = kargs.get('byref', False)
+        resultMode = kargs.get('resultMode', HproseResultMode.Normal)
+        simple = kargs.get('simple', None)
+        rt = await self.__invoke(self.__name, list(args), callback, onerror, byref, resultMode, simple)
+        return rt
+
+
+class HproseClient(OldClient):
+    def __getattr__(self, name):
+        return _Method(self.invoke, name)
+
+    async def invoke(self, name, args=(), callback=None, onerror=None, byref=False,
+                     resultMode=HproseResultMode.Normal, simple=None):
+        """
+        :param name: str
+        :param args: List
+        :param callback:
+        :param onerror:
+        :param byref: 是否为引用参数传递
+            见 https://github.com/hprose/hprose-php/wiki/05.-Hprose-%E5%AE%A2%E6%88%B7%E7%AB%AF#byref-%E5%B1%9E%E6%80%A7
+        :param resultMode:
+            见 https://github.com/hprose/hprose-php/wiki/05.-Hprose-%E5%AE%A2%E6%88%B7%E7%AB%AF#mode
+        :param simple: 是否为简单数据
+            见 https://github.com/hprose/hprose-php/wiki/05.-Hprose-%E5%AE%A2%E6%88%B7%E7%AB%AF#simple-%E5%B1%9E%E6%80%A7
+        :return:
+        """
+        if simple is None:
+            simple = self.simple
+        if callback is None:
+            result = await self._invoke(name, args, byref, resultMode, simple)
+            return result
+        else:
+            if isinstance(callback, str):
+                callback = getattr(sys.modules['__main__'], callback, None)
+            if not hasattr(callback, '__call__'):
+                raise RuntimeError("callback must be callable")
+            if onerror is None:
+                onerror = self.onError
+            if onerror is not None:
+                if isinstance(onerror, str):
+                    onerror = getattr(sys.modules['__main__'], onerror, None)
+                if not hasattr(onerror, '__call__'):
+                    raise RuntimeError("onerror must be callable")
+
+            result = await _AsyncInvoke(
+                self._invoke, name, args,
+                callback, onerror, byref,
+                resultMode, simple)()
+
+            return result
+
+    async def _invoke(self, name, args, byref, resultMode, simple):
+        data = self._doOutput(name, args, byref, simple)
+        recv = await self._sendAndReceive(data)
+        return self._doInput(recv, args, resultMode)

--- a/python3/hprose/tornado/httpclient.py
+++ b/python3/hprose/tornado/httpclient.py
@@ -1,0 +1,54 @@
+import tornado.httpclient
+
+from .client import HproseClient
+from ..httpclient import (
+    HproseHttpClient as OldHttpClient,
+    _setCookie,
+    _getCookie,
+)
+from ..common import NetErrorException
+
+
+class HproseHttpClient(HproseClient, OldHttpClient):
+    def __init__(self, uri=None):
+        HproseClient.__init__(self, uri)
+        OldHttpClient.__init__(self, uri)
+
+    async def _sendAndReceive(self, data):
+        header = {'Content-Type': 'application/hprose'}
+        header['Host'] = self._host
+        if self._port != 80:
+            header['Host'] += ':' + str(self._port)
+        cookie = _getCookie(self._host, self._path, self._scheme == 'https')
+        if cookie != '':
+            header['Cookie'] = cookie
+        if self.keepAlive:
+            header['Connection'] = 'keep-alive'
+            header['Keep-Alive'] = str(self.keepAliveTimeout)
+        else:
+            header['Connection'] = 'close'
+        for name in self._header:
+            header[name] = self._header[name]
+
+        httpclient = tornado.httpclient.AsyncHTTPClient()
+        request = tornado.httpclient.HTTPRequest(
+            url=self._uri,
+            method='POST',
+            headers=header,
+            body=data,
+            request_timeout=self.timeout,
+        )
+        # TODO 暂时不支持代理，因为需要tornado在启动时设置
+        # AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
+        # 才行，条件过于苛刻
+        try:
+            response = await httpclient.fetch(request)
+        except (tornado.httpclient.HTTPError, ConnectionRefusedError) as err:
+            # TODO 需要将网络异常和逻辑异常分开处理
+            raise NetErrorException(str(err))
+        else:
+            # 检查是否有set-Cookie头，需要缓存cookie用于下一次的通讯
+            cookie_list = response.headers.get_list("set-cookie")  # type: list
+            cookie_list.extend(response.headers.get_list("set-cookie2"))
+            _setCookie(cookie_list, self._host)
+            return response.body

--- a/test/cookie.py
+++ b/test/cookie.py
@@ -1,0 +1,21 @@
+import unittest
+from python3.hprose.httpclient import _getCookie, _setCookie
+
+
+class CookieTest(unittest.TestCase):
+    def test_a(self):
+        _setCookie(['a=1'], '127.0.0.1')
+        cookie = _getCookie('127.0.0.1', '/a/b', False)
+        print("cookie a: ", cookie)
+        self.assertEqual(cookie, 'a=1')
+        self.assertEqual(_getCookie('localhost', '/', False), '')
+        _setCookie(['b=c; path=/c'], '127.0.0.1')
+        print("cookie b: ", _getCookie('127.0.0.1', '/c', False))
+        self.assertEqual(_getCookie('127.0.0.1', '/', False), 'a=1')
+        self.assertEqual(_getCookie('127.0.0.1', '/c', False), 'a=1; b=c')
+        self.assertEqual(_getCookie('127.0.0.1', '/c/d', False), 'a=1; b=c')
+        self.assertEqual(_getCookie('127.0.0.1', '/d', False), 'a=1')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/tornado/httpclient.py
+++ b/test/tornado/httpclient.py
@@ -1,0 +1,140 @@
+import logging
+import time
+import tornado.testing
+import tornado.web
+import tornado.gen
+import tornado.wsgi
+import python3.hprose as hprose
+from python3.hprose.tornado import httpclient
+
+logger = logging.getLogger(__name__)
+for handle in logger.handlers:
+    handle.setLevel(logging.DEBUG)
+logger.setLevel(logging.DEBUG)
+
+
+def hello(name):
+    return 'Hello %s!' % name
+
+
+def error(name):
+    raise RuntimeError('{} 异常测试'.format(name))
+
+
+service = hprose.HttpService()
+service.addFunction(hello)
+service.addFunction(error)
+
+
+class TestHandler(tornado.web.RequestHandler):
+    @tornado.gen.coroutine
+    def get(self):
+        # hprose的service只接受wsgi的environ，因此需要将request对象转为environ对象再传给hprose处理
+        environ = tornado.wsgi.WSGIContainer.environ(self.request)
+        status, headers, body = service(environ)
+        # 返回响应
+        self.set_status(int(status.split(' ')[0]))
+        for name, value in headers:
+            self.add_header(name, value)
+        yield tornado.gen.sleep(1)
+        self.finish(body[0])
+
+    @tornado.gen.coroutine
+    def post(self):
+        # hprose的service只接受wsgi的environ，因此需要将request对象转为environ对象再传给hprose处理
+        environ = tornado.wsgi.WSGIContainer.environ(self.request)
+        logger.debug('request cookies:{}'.format(self.cookies))
+        logger.debug('cookie a: {}'.format(self.get_cookie('a', '***')))
+        logger.debug('cookie bbb: {}'.format(self.get_cookie('bbb', '***')))
+        status, headers, body = service(environ)
+        # 返回响应
+        self.set_status(int(status.split(' ')[0]))
+        for name, value in headers:
+            self.add_header(name, value)
+        yield tornado.gen.sleep(1)
+        self.finish(body[0])
+        logger.debug('请求完成')
+
+
+class Application(tornado.web.Application):
+    def __init__(self):
+        handlers = [
+            (r"/hprose", TestHandler),
+        ]
+        settings = dict(
+            xsrf_cookies=False,
+        )
+        super(Application, self).__init__(handlers, **settings)
+
+
+class HttpClientTest(tornado.testing.AsyncHTTPTestCase):
+    def get_app(self):
+        return Application()
+
+    def test_http_fetch(self):
+        response = self.fetch('/hprose')
+        # response = yield self.http_client.fetch(self.get_url('/'))
+        logger.debug(response.body)
+        self.assertEqual(response.code, 200)
+        self.assertIn("hello", response.body.decode())
+
+    @tornado.testing.gen_test
+    async def test_hprose(self):
+        try:
+            rpc_client = httpclient.HproseHttpClient(uri=self.get_url("/hprose"))
+            arg = "world"
+            rt = await rpc_client.hello(arg)
+            logger.debug(rt)
+            self.assertIn(arg, rt)
+        finally:
+            self.stop()
+
+    @tornado.testing.gen_test
+    async def test_muti(self):
+        try:
+            rpc_client = httpclient.HproseHttpClient(uri=self.get_url("/hprose"))
+            arg = "world"
+            # 多个请求并行
+            start = time.time()
+            f1 = rpc_client.hello(arg)
+            f2 = rpc_client.hello(arg)
+            f3 = rpc_client.hello(arg)
+            rt = await tornado.gen.multi([f1, f2, f3])
+            logger.debug(rt)
+            self.assertIn(arg, rt[0])
+            self.assertLess(time.time() - start, 2)
+        finally:
+            self.stop()
+
+    @tornado.testing.gen_test
+    async def test_error(self):
+        try:
+            # 服务方主动抛出的异常
+            with self.assertRaises(hprose.common.ServiceException):
+                rpc_client = httpclient.HproseHttpClient(uri=self.get_url("/hprose"))
+                arg = "aaa"
+                rt = await rpc_client.error(arg)
+                logger.debug(rt)
+                self.assertIn(arg, rt)
+
+            # 不存在的方法
+            with self.assertRaises(hprose.common.ServiceException):
+                rpc_client = httpclient.HproseHttpClient(uri=self.get_url("/hprose"))
+                arg = "aaa"
+                rt = await rpc_client.aaa(arg)
+                logger.debug(rt)
+                self.assertIn(arg, rt)
+
+            # 端口错误
+            with self.assertRaises(hprose.common.NetErrorException):
+                rpc_client = httpclient.HproseHttpClient(uri='http://localhost:8888/hprose')
+                arg = "aaa"
+                rt = await rpc_client.hello(arg)
+                logger.debug(rt)
+                self.assertIn(arg, rt)
+        finally:
+            self.stop()
+
+
+if __name__ == "__main__":
+    tornado.testing.main()

--- a/test/tornado/httpserver.py
+++ b/test/tornado/httpserver.py
@@ -1,0 +1,69 @@
+import tornado.testing
+import tornado.web
+import tornado.gen
+import tornado.wsgi
+import tornado.util
+
+if tornado.util.PY3:
+    from python3 import hprose
+else:
+    from python2 import hprose
+
+
+def hello(name):
+    return 'Hello %s!' % name
+
+
+service = hprose.HttpService()
+service.addFunction(hello)
+
+
+class TestHandler(tornado.web.RequestHandler):
+    @tornado.gen.coroutine
+    def get(self):
+        # hprose的service只接受wsgi的environ，因此需要将request对象转为environ对象再传给hprose处理
+        environ = tornado.wsgi.WSGIContainer.environ(self.request)
+        status, headers, body = service(environ)
+        # 返回响应
+        self.set_status(int(status.split(' ')[0]))
+        for name, value in headers:
+            self.add_header(name, value)
+        yield tornado.gen.sleep(2)
+        self.finish(body[0])
+
+    @tornado.gen.coroutine
+    def post(self):
+        # hprose的service只接受wsgi的environ，因此需要将request对象转为environ对象再传给hprose处理
+        environ = tornado.wsgi.WSGIContainer.environ(self.request)
+        status, headers, body = service(environ)
+        # 返回响应
+        self.set_status(int(status.split(' ')[0]))
+        for name, value in headers:
+            self.add_header(name, value)
+        yield tornado.gen.sleep(2)
+        self.finish(body[0])
+
+
+class Application(tornado.web.Application):
+    def __init__(self):
+        handlers = [
+            (r"/", TestHandler),
+        ]
+        settings = dict(
+            xsrf_cookies=False,
+        )
+        super(Application, self).__init__(handlers, **settings)
+
+
+class HttpServerTest(tornado.testing.AsyncTestCase):
+    def test_start_server(self):
+        pass
+
+
+if __name__ == "__main__":
+    tornado.testing.main()
+    import tornado.ioloop
+
+    app = Application()
+    app.listen(8888)
+    tornado.ioloop.IOLoop.current().start()


### PR DESCRIPTION
1. 重写了HproseClient和HproseHttpClient两个类，加入了async和await，使客户端能够运行在tornado这样的协程服务器上
2. 新建了NetErrorExcepiton和ServiceException两个异常，继承自HproseException，用于把网络异常和服务端主动抛出的异常分开。